### PR TITLE
Moves the region to the replay object.

### DIFF
--- a/app/Player.php
+++ b/app/Player.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $hero_level
  * @property int $team
  * @property bool $winner
- * @property int|null $region
  * @property int|null $blizz_id
  * @property-read \App\Replay $replay
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Player whereBattletag($value)

--- a/app/Replay.php
+++ b/app/Replay.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $game_type
  * @property string $fingerprint
  * @property string|null $game_version
+ * @property int|null $region
  * @property-read string $url
  * @property-read \Illuminate\Database\Eloquent\Collection|\App\Player[] $players
  * @method static \Illuminate\Database\Eloquent\Builder|\App\Replay whereCreatedAt($value)

--- a/app/Services/ParserService.php
+++ b/app/Services/ParserService.php
@@ -94,14 +94,18 @@ class ParserService
             }
 
             $winnerCheck = false;
+            $result->region = null;
             foreach ($replay->details->m_playerList as $i => $player) {
+                if ($result->region === null) {
+                    $result->region = $player->m_toon->m_region;
+                }
+
                 $playerData = [
                     // todo extract full battletag from battlelobby
                     'battletag' => utf8_decode($player->m_name),
                     'hero' => mb_strtolower(utf8_decode($player->m_hero)), // convert to lower case for translation
                     'team' => $player->m_teamId,
                     'winner' => $player->m_result == 1,
-                    'region' => $player->m_toon->m_region,
                     'blizz_id' => $player->m_toon->m_id,
                 ];
 
@@ -116,7 +120,7 @@ class ParserService
                     return $result;
                 }
 
-                if ($playerData["region"] > 90) {
+                if ($result->region > 90) {
                     $result->status = self::STATUS_PTR_REGION;
                     return $result;
                 }

--- a/app/Services/ReplayService.php
+++ b/app/Services/ReplayService.php
@@ -50,6 +50,7 @@ class ReplayService
             $replay = new Replay($parseResult->data);
             $replay->filename = $filename;
             $replay->size = $file->getSize();
+            $replay->region = $parseResult->region;
             // todo fix replay encodings
             $replay->save();
             foreach ($parseResult->data['players'] as $playerData) {


### PR DESCRIPTION
The replay structure seems to indicate the region on a per-player basis (toon -> region) but this should always be identical within a single match, and so we can move it up to the replay object level.

This should address #5.  I didn't add any down migration here because it's destructive overall.  I mean, I guess you need to rebuild the database either way, so it wouldn't hurt to have the rollback be functional?  Not sure, you tell me how much you think it matters. :)