### PR TITLE
Minor html attribute typo

### DIFF
--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -61,7 +61,7 @@
     <hr>
 
     <h1>Or you can use the web uploader</h1>
-    <p>Choose replay files, or drag them onto this page. <span id="container_fileupload_dir_text hidden">Chrome users: If you are uploading &gt;700 replays, please select by directory</span></p>
+    <p>Choose replay files, or drag them onto this page. <span id="container_fileupload_dir_text" class="hidden">Chrome users: If you are uploading &gt;700 replays, please select by directory</span></p>
 
     <span class="btn btn-success fileinput-button">
         <i class="glyphicon glyphicon-plus"></i>


### PR DESCRIPTION
minor typo: `hidden` should have been a `class` attribute, not part of the `id` attribute. this has no functional impact on the page, just hides the chrome directory upload warning from people who can't use directories anyway.