### PR TITLE
Add pagination metadata to the API

### DIFF
--- a/app/Http/Controllers/ReplayController.php
+++ b/app/Http/Controllers/ReplayController.php
@@ -50,7 +50,7 @@ class ReplayController extends Controller
     public function index(Request $request)
     {
         $query = getQuery($request)
-        return $query->orderBy('id')->limit(ReplayController::PAGE_SIZE)->get();
+        return $query->limit(ReplayController::PAGE_SIZE)->get();
     }
 
     /**
@@ -63,10 +63,8 @@ class ReplayController extends Controller
     {
         $total = $query->count();
         $pageCount = $total / ReplayController::PAGE_SIZE;
-        $metadata = ['per_page' => ReplayController::PAGE_SIZE, 'page' => $page, 'page_count' => $pageCount, 'total' => $pageCount];
-        $replays = $query->orderBy('id')->forPage($page, ReplayController::PAGE_SIZE)->get();
-
-        $response = ['_metadata' => $metadata, 'Replays' => $replays];
+        $replays = $query->forPage($page, ReplayController::PAGE_SIZE)->get();
+        $response = ['per_page' => ReplayController::PAGE_SIZE, 'page' => $page, 'page_count' => $pageCount, 'total' => $total, 'Replays' => $replays];
 
         return $response()->json();
     }
@@ -198,6 +196,6 @@ class ReplayController extends Controller
             $query->with('players');
         }
 
-        return $query;
+        return $query->orderBy('id');
     }
 }

--- a/app/Http/Controllers/ReplayController.php
+++ b/app/Http/Controllers/ReplayController.php
@@ -8,9 +8,11 @@ use App\Replay;
 use App\Services\ParserService;
 use App\Services\ReplayService;
 use Illuminate\Http\Request;
+use Illuminate\Support;
 
 class ReplayController extends Controller
 {
+    // Number of replays per page
     const PAGE_SIZE = 100; 
 
     /**
@@ -47,57 +49,25 @@ class ReplayController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Replay::query();
+        $query = getQuery($request)
+        return $query->orderBy('id')->limit(ReplayController::PAGE_SIZE)->get();
+    }
 
-        $page = 1;
-
-        if ($request->page) {
-            $page = $request->page;
-        }
-
-        if ($request->start_date) {
-            $query->where('game_date', '>=', $request->start_date);
-        }
-
-        if ($request->end_date) {
-            $query->where('game_date', '<=', $request->end_date);
-        }
-
-        if ($request->game_map) {
-            $query->where('game_map', $request->game_map);
-        }
-
-        if ($request->game_type) {
-            $query->where('game_type', $request->game_type);
-        }
-
-        if ($request->min_id) {
-            $query->where('id', '>=', $request->min_id);
-        }
-
-        if ($request->player) {
-            $query->whereHas('players', function ($query) use ($request) {
-                $query->where('battletag', $request->player);
-            });
-        }
-
-        if ($request->hero) {
-            $query->whereHas('players', function ($query) use ($request) {
-                $query->where('hero', $request->hero);
-            });
-        }
-
-        if ($request->with_players) {
-            $query->with('players');
-        }
-
+    /**
+     * Show replay list with page metadata
+     * 
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function paged(Request $request)
+    {
         $total = $query->count();
         $pageCount = $total / ReplayController::PAGE_SIZE;
         $metadata = ['per_page' => ReplayController::PAGE_SIZE, 'page' => $page, 'page_count' => $pageCount, 'total' => $pageCount];
         $replays = $query->orderBy('id')->forPage($page, ReplayController::PAGE_SIZE)->get();
 
         $response = ['_metadata' => $metadata, 'Replays' => $replays];
-        
+
         return $response()->json();
     }
 
@@ -181,5 +151,53 @@ class ReplayController extends Controller
     public function mapTranslations()
     {
         return Map::with('translations')->get();
+    }
+
+    /**
+     * Creates a query object for replays based on a request 
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    private function getQuery(Request $request)
+    {
+        $query = Replay::query();
+
+        if ($request->start_date) {
+            $query->where('game_date', '>=', $request->start_date);
+        }
+
+        if ($request->end_date) {
+            $query->where('game_date', '<=', $request->end_date);
+        }
+
+        if ($request->game_map) {
+            $query->where('game_map', $request->game_map);
+        }
+
+        if ($request->game_type) {
+            $query->where('game_type', $request->game_type);
+        }
+
+        if ($request->min_id) {
+            $query->where('id', '>=', $request->min_id);
+        }
+
+        if ($request->player) {
+            $query->whereHas('players', function ($query) use ($request) {
+                $query->where('battletag', $request->player);
+            });
+        }
+
+        if ($request->hero) {
+            $query->whereHas('players', function ($query) use ($request) {
+                $query->where('hero', $request->hero);
+            });
+        }
+
+        if ($request->with_players) {
+            $query->with('players');
+        }
+
+        return $query;
     }
 }

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -44,6 +44,11 @@
         </tr>
         <tr>
             <td>GET</td>
+            <td>/pagedreplays</td>
+            <td>Get a list of paginated replays</td>
+        </tr>
+        <tr>
+            <td>GET</td>
             <td>/replays/{id}</td>
             <td>Get replay details</td>
         </tr>
@@ -171,8 +176,44 @@
 ]
 </code></pre>
 
+    <h3><code>GET /pagedreplays</code></h3>
+    <p>Get all replays, like <code>/replays</code>, but with metadata for pagination</p> 
+    <p>This method takes an addition page parameter, indicating the current page number. Empty is assumed to be 1</p>
+    <table class="table table-sm table-striped">
+        <tbody>
+            <tr>
+                <td>_metadata</td>
+                <td>
+                    <table class="table table-sm table-striped">
+                        <tbody>
+                            <tr>
+                                <td>per_page</td>
+                                <td>Items per page</td>
+                            </tr>
+                            <tr> 
+                                <td>page</td>
+                                <td>Current page</td>
+                            </tr>
+                            <tr>
+                                <td>page_count</td>
+                                <td>Total pages available</td>
+                            </tr>
+                            <tr>
+                                <td>total</td>
+                                <td>Total items available</td>
+                            </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td>Replays</td>
+                <td>See /replays above for returned schema</td>
+            </tr>
+        </tbody>
+    </table>
+
     <h3><code>GET /replays/{id}</code></h3>
-    <p>Get replay data by database id. Returns same values as <code>GET /replays</code> with an additionas <code>players</code> array:</p>
+    <p>Get replay data by database id. Returns same values as <code>GET /replays</code> with an additional <code>players</code> array:</p>
     <table class="table table-sm table-striped">
         <tbody>
         <tr>

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@
 */
 
 Route::get ('replays', 'ReplayController@index'); //start_date end_date map game_type player min_id
+Route::get ('pagedreplays', 'ReplayController@paged'); //start_date end_date map game_type player min_id page
 Route::post('upload', 'ReplayController@store');
 Route::post('replays', 'ReplayController@store');
 Route::get ('replays/fingerprints/v2/{fingerprint}', 'ReplayController@checkV2');

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,7 +12,7 @@
 */
 
 Route::get ('replays', 'ReplayController@index'); //start_date end_date map game_type player min_id
-Route::get ('pagedreplays', 'ReplayController@paged'); //start_date end_date map game_type player min_id page
+Route::get ('replays/paged', 'ReplayController@paged'); //start_date end_date map game_type player min_id page
 Route::post('upload', 'ReplayController@store');
 Route::post('replays', 'ReplayController@store');
 Route::get ('replays/fingerprints/v2/{fingerprint}', 'ReplayController@checkV2');


### PR DESCRIPTION
Create a new /pagedreplays  api to get replays with pagination information. The structure returned is outlined below. It shares the same code as /replays, with the addition of taking in a $page parameter to indicate what page should be retrieved. 

{ 
    "page": number,
    "page_count": number,
    "total": number,
    "per_page": number
   "Replays": []
}