### PR TITLE
Add www subdomain to HeroesProfile link

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -55,7 +55,7 @@
                 <a target="_blank" href="https://play.google.com/store/apps/details?id=com.heroescompanion.app" class="partner-link"><img src="{{asset('/img/logo-heroescompanion.png')}}"></a>
     			      <a target="_blank" href="https://hots.academy" class="partner-link"><img src="{{asset('/img/logo-hotsacademy.png')}}"></a>
     			      <a target="_blank" href="https://heroesshare.net" class="partner-link"><img src="{{asset('/img/logo-heroesshare.png')}}"></a>
-          	    <a target="_blank" href="https://heroesprofile.com" class="partner-link"><img src="{{asset('/img/logo-heroesprofile.png')}}"></a>
+          	    <a target="_blank" href="https://www.heroesprofile.com" class="partner-link"><img src="{{asset('/img/logo-heroesprofile.png')}}"></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
On my version of Safari, the fraudulent website / cert mis-match error is triggering before the redirect hits, as the cert for the site is tied to www.heroesprofile.com and not heroesprofile.com

https://heroesprofile.com is a 301 redirect to https://www.heroesprofile.com , so save a round trip as well